### PR TITLE
Eliminate the usage of unwrap in Wkb::try_new

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -161,10 +161,10 @@ impl WKBType {
     /// Construct from a byte slice representing a WKB geometry
     pub(crate) fn from_buffer(buf: &[u8]) -> WKBResult<Self> {
         let mut reader = Cursor::new(buf);
-        let byte_order = reader.read_u8().unwrap();
+        let byte_order = reader.read_u8()?;
         let geometry_code = match byte_order {
-            0 => reader.read_u32::<BigEndian>().unwrap(),
-            1 => reader.read_u32::<LittleEndian>().unwrap(),
+            0 => reader.read_u32::<BigEndian>()?,
+            1 => reader.read_u32::<LittleEndian>()?,
             other => {
                 return Err(WKBError::General(format!(
                     "Unexpected byte order: {}",

--- a/src/reader/geometry.rs
+++ b/src/reader/geometry.rs
@@ -7,7 +7,7 @@ use geo_traits_ext::{
 };
 
 use crate::common::{WKBDimension, WKBType};
-use crate::error::WKBResult;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::{
     GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon, Point, Polygon,
 };
@@ -96,19 +96,24 @@ pub(crate) enum WkbInner<'a> {
 impl<'a> WkbInner<'a> {
     fn try_new(buf: &'a [u8]) -> WKBResult<Self> {
         let mut reader = Cursor::new(buf);
-        let byte_order = Endianness::try_from(reader.read_u8()?).unwrap();
+        let byte_order = Endianness::try_from(reader.read_u8()?)
+            .map_err(|_| WKBError::General("Invalid byte order".to_string()))?;
         let wkb_type = WKBType::from_buffer(buf)?;
 
         let out = match wkb_type {
-            WKBType::Point(dim) => Self::Point(Point::new(buf, byte_order, 0, dim)),
-            WKBType::LineString(dim) => Self::LineString(LineString::new(buf, byte_order, 0, dim)),
-            WKBType::Polygon(dim) => Self::Polygon(Polygon::new(buf, byte_order, 0, dim)),
-            WKBType::MultiPoint(dim) => Self::MultiPoint(MultiPoint::new(buf, byte_order, dim)),
+            WKBType::Point(dim) => Self::Point(Point::try_new(buf, byte_order, 0, dim)?),
+            WKBType::LineString(dim) => {
+                Self::LineString(LineString::try_new(buf, byte_order, 0, dim)?)
+            }
+            WKBType::Polygon(dim) => Self::Polygon(Polygon::try_new(buf, byte_order, 0, dim)?),
+            WKBType::MultiPoint(dim) => {
+                Self::MultiPoint(MultiPoint::try_new(buf, byte_order, dim)?)
+            }
             WKBType::MultiLineString(dim) => {
-                Self::MultiLineString(MultiLineString::new(buf, byte_order, dim))
+                Self::MultiLineString(MultiLineString::try_new(buf, byte_order, dim)?)
             }
             WKBType::MultiPolygon(dim) => {
-                Self::MultiPolygon(MultiPolygon::new(buf, byte_order, dim))
+                Self::MultiPolygon(MultiPolygon::try_new(buf, byte_order, dim)?)
             }
             WKBType::GeometryCollection(dim) => {
                 Self::GeometryCollection(GeometryCollection::try_new(buf, byte_order, dim)?)
@@ -194,48 +199,51 @@ impl<'a> GeometryTrait for Wkb<'a> {
     }
 }
 
-impl<'a> GeometryTrait for &Wkb<'a> {
+impl<'a, 'b> GeometryTrait for &'b Wkb<'a>
+where
+    'a: 'b,
+{
     type T = f64;
-    type PointType<'b>
+    type PointType<'inner_b>
         = Point<'a>
     where
-        Self: 'b;
-    type LineStringType<'b>
+        Self: 'inner_b;
+    type LineStringType<'inner_b>
         = LineString<'a>
     where
-        Self: 'b;
-    type PolygonType<'b>
+        Self: 'inner_b;
+    type PolygonType<'inner_b>
         = Polygon<'a>
     where
-        Self: 'b;
-    type MultiPointType<'b>
+        Self: 'inner_b;
+    type MultiPointType<'inner_b>
         = MultiPoint<'a>
     where
-        Self: 'b;
-    type MultiLineStringType<'b>
+        Self: 'inner_b;
+    type MultiLineStringType<'inner_b>
         = MultiLineString<'a>
     where
-        Self: 'b;
-    type MultiPolygonType<'b>
+        Self: 'inner_b;
+    type MultiPolygonType<'inner_b>
         = MultiPolygon<'a>
     where
-        Self: 'b;
-    type GeometryCollectionType<'b>
+        Self: 'inner_b;
+    type GeometryCollectionType<'inner_b>
         = GeometryCollection<'a>
     where
-        Self: 'b;
-    type RectType<'b>
+        Self: 'inner_b;
+    type RectType<'inner_b>
         = UnimplementedRect<f64>
     where
-        Self: 'b;
-    type TriangleType<'b>
+        Self: 'inner_b;
+    type TriangleType<'inner_b>
         = UnimplementedTriangle<f64>
     where
-        Self: 'b;
-    type LineType<'b>
+        Self: 'inner_b;
+    type LineType<'inner_b>
         = UnimplementedLine<f64>
     where
-        Self: 'b;
+        Self: 'inner_b;
 
     fn dim(&self) -> Dimensions {
         self.dimension().into()

--- a/src/reader/geometry_collection.rs
+++ b/src/reader/geometry_collection.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
-use crate::error::WKBResult;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::reader::Wkb;
 use crate::Endianness;
@@ -26,14 +26,17 @@ pub struct GeometryCollection<'a> {
 impl<'a> GeometryCollection<'a> {
     pub fn try_new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> WKBResult<Self> {
         let mut offset = 0;
-        let has_srid = has_srid(buf, byte_order, offset);
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
 
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
-        let num_geometries = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_geometries = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of geometries: {}", e)))?;
 
         // - 1: byteOrder
         // - 4: wkbType

--- a/src/reader/linearring.rs
+++ b/src/reader/linearring.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::coord::Coord;
 use crate::reader::coord_iter::*;
 use crate::reader::util::ReadBytesExt;
@@ -41,17 +42,49 @@ pub struct WKBLinearRing<'a> {
 
 impl<'a> WKBLinearRing<'a> {
     pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, offset, dim).unwrap()
+    }
+
+    pub fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        offset: u64,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
         let mut reader = Cursor::new(buf);
         reader.set_position(offset);
-        let num_points = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_points = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of points: {}", e)))?;
 
-        Self {
+        let ring = Self {
             buf,
             byte_order,
-            offset,
+            offset, // This offset is where num_points for this ring starts
             num_points,
             dim,
+        };
+
+        // `offset` is the start of the num_points field. `ring.size()` is `4 (for num_points) + coord_data`.
+        let expected_end_abs = offset + ring.size();
+        if expected_end_abs > buf.len() as u64 {
+            return Self::handle_invalid_buffer_length(offset, expected_end_abs, buf.len());
         }
+
+        Ok(ring)
+    }
+
+    #[cold]
+    fn handle_invalid_buffer_length(
+        offset: u64,
+        expected_end_abs: u64,
+        buf_len: usize,
+    ) -> WKBResult<Self> {
+        Err(WKBError::General(format!(
+            "Invalid buffer length for LinearRing: data starting at offset {} would end at byte {}, but buffer length is {}.",
+            offset, expected_end_abs, buf_len
+        )))
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/linestring.rs
+++ b/src/reader/linestring.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::coord::Coord;
 use crate::reader::coord_iter::*;
 use crate::reader::util::{has_srid, ReadBytesExt};
@@ -33,24 +34,59 @@ pub struct LineString<'a> {
 }
 
 impl<'a> LineString<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
-        let has_srid = has_srid(buf, byte_order, offset);
+    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, offset, dim).unwrap()
+    }
+
+    pub fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        mut offset: u64,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
 
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
-        let num_points = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_points = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of points: {}", e)))?;
 
-        Self {
+        let linestring = Self {
             buf,
             byte_order,
             num_points,
             offset,
             dim,
             has_srid,
+        };
+
+        let expected_end_abs = linestring.coord_offset(num_points as u64);
+        if expected_end_abs > buf.len() as u64 {
+            return Self::handle_invalid_buffer_length(
+                linestring.offset,
+                expected_end_abs,
+                buf.len(),
+            );
         }
+
+        Ok(linestring)
+    }
+
+    #[cold]
+    fn handle_invalid_buffer_length(
+        offset: u64,
+        expected_end_abs: u64,
+        buf_len: usize,
+    ) -> WKBResult<Self> {
+        Err(WKBError::General(format!(
+            "Invalid buffer length for LineString: geometry starting at offset {} would end at byte {}, but buffer length is {}.",
+            offset, expected_end_abs, buf_len
+        )))
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/multilinestring.rs
+++ b/src/reader/multilinestring.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::linestring::LineString;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -24,16 +25,28 @@ pub struct MultiLineString<'a> {
 }
 
 impl<'a> MultiLineString<'a> {
+    #[allow(dead_code)]
     pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, dim).unwrap()
+    }
+
+    pub(crate) fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
         let mut offset = 0;
-        let has_srid = has_srid(buf, byte_order, offset);
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
 
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
-        let num_line_strings = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_line_strings = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of line strings: {}", e)))?;
 
         // - 1: byteOrder
         // - 4: wkbType
@@ -45,16 +58,16 @@ impl<'a> MultiLineString<'a> {
 
         let mut wkb_line_strings = Vec::with_capacity(num_line_strings);
         for _ in 0..num_line_strings {
-            let ls = LineString::new(buf, byte_order, line_string_offset, dim);
+            let ls = LineString::try_new(buf, byte_order, line_string_offset, dim)?;
             wkb_line_strings.push(ls);
             line_string_offset += ls.size();
         }
 
-        Self {
+        Ok(Self {
             wkb_line_strings,
             dim,
             has_srid,
-        }
+        })
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/multipoint.rs
+++ b/src/reader/multipoint.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::point::Point;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -24,9 +25,18 @@ pub struct MultiPoint<'a> {
 }
 
 impl<'a> MultiPoint<'a> {
+    #[allow(dead_code)]
     pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, dim).unwrap()
+    }
+
+    pub(crate) fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
         let mut offset = 0;
-        let has_srid = has_srid(buf, byte_order, offset);
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
@@ -34,15 +44,33 @@ impl<'a> MultiPoint<'a> {
         let mut reader = Cursor::new(buf);
         // Set reader to after 1-byte byteOrder and 4-byte wkbType
         reader.set_position(1 + 4 + offset);
-        let num_points = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_points = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of points: {}", e)))?;
 
-        Self {
+        let multipoint = Self {
             buf,
             byte_order,
             num_points,
             dim,
             has_srid,
+        };
+
+        let end_offset = multipoint.point_offset(num_points as u64);
+        if end_offset > buf.len() as u64 {
+            return Self::handle_invalid_buffer_length(end_offset, buf.len());
         }
+
+        Ok(multipoint)
+    }
+
+    #[cold]
+    fn handle_invalid_buffer_length(expected_end_abs: u64, buf_len: usize) -> WKBResult<Self> {
+        Err(WKBError::General(format!(
+            "Invalid buffer length for MultiPoint: geometry would end at byte {}, but buffer length is {}.",
+            expected_end_abs, buf_len
+        )))
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/multipolygon.rs
+++ b/src/reader/multipolygon.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::polygon::Polygon;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -24,16 +25,28 @@ pub struct MultiPolygon<'a> {
 }
 
 impl<'a> MultiPolygon<'a> {
+    #[allow(dead_code)]
     pub(crate) fn new(buf: &'a [u8], byte_order: Endianness, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, dim).unwrap()
+    }
+
+    pub(crate) fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
         let mut offset = 0;
-        let has_srid = has_srid(buf, byte_order, offset);
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
 
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
-        let num_polygons = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_polygons = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of polygons: {}", e)))?;
 
         // - 1: byteOrder
         // - 4: wkbType
@@ -45,16 +58,16 @@ impl<'a> MultiPolygon<'a> {
 
         let mut wkb_polygons = Vec::with_capacity(num_polygons);
         for _ in 0..num_polygons {
-            let polygon = Polygon::new(buf, byte_order, polygon_offset, dim);
+            let polygon = Polygon::try_new(buf, byte_order, polygon_offset, dim)?;
             polygon_offset += polygon.size();
             wkb_polygons.push(polygon);
         }
 
-        Self {
+        Ok(Self {
             wkb_polygons,
             dim,
             has_srid,
-        }
+        })
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/point.rs
+++ b/src/reader/point.rs
@@ -1,4 +1,6 @@
 use crate::common::WKBDimension;
+use crate::error::WKBError;
+use crate::error::WKBResult;
 use crate::reader::coord::Coord;
 use crate::reader::util::has_srid;
 use crate::Endianness;
@@ -28,16 +30,30 @@ impl<'a> Point<'a> {
         offset: u64,
         dim: WKBDimension,
     ) -> Self {
-        let has_srid = has_srid(buf, byte_order, offset);
+        Self::try_new(buf, byte_order, offset, dim).unwrap()
+    }
+
+    pub(crate) fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        offset: u64,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
+        let has_srid = has_srid(buf, byte_order, offset)?;
 
         // The space of the byte order + geometry type
-        let mut offset = offset + 5;
+        let mut current_offset = offset + 5;
         if has_srid {
             // Skip SRID bytes if they exist
-            offset += 4;
+            current_offset += 4;
         }
 
-        let coord = Coord::new(buf, byte_order, offset, dim);
+        let expected_end = current_offset as usize + dim.size() * 8;
+        if buf.len() < expected_end {
+            return Self::handle_invalid_buffer_length(offset, expected_end, buf.len());
+        }
+
+        let coord = Coord::new(buf, byte_order, current_offset, dim);
         let is_empty = (0..coord.dim().size()).all(|coord_dim| {
             {
                 // Safety:
@@ -47,12 +63,24 @@ impl<'a> Point<'a> {
             }
             .is_nan()
         });
-        Self {
+        Ok(Self {
             coord,
             dim,
             is_empty,
             has_srid,
-        }
+        })
+    }
+
+    #[cold]
+    fn handle_invalid_buffer_length(
+        offset: u64,
+        expected_end: usize,
+        buf_len: usize,
+    ) -> WKBResult<Self> {
+        Err(WKBError::General(format!(
+            "Invalid buffer length for Point: geometry starting at offset {} would end at byte {}, but buffer length is {}.",
+            offset, expected_end, buf_len
+        )))
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/polygon.rs
+++ b/src/reader/polygon.rs
@@ -1,6 +1,7 @@
 use std::io::Cursor;
 
 use crate::common::WKBDimension;
+use crate::error::{WKBError, WKBResult};
 use crate::reader::linearring::WKBLinearRing;
 use crate::reader::util::{has_srid, ReadBytesExt};
 use crate::Endianness;
@@ -23,8 +24,17 @@ pub struct Polygon<'a> {
 }
 
 impl<'a> Polygon<'a> {
-    pub fn new(buf: &'a [u8], byte_order: Endianness, mut offset: u64, dim: WKBDimension) -> Self {
-        let has_srid = has_srid(buf, byte_order, offset);
+    pub fn new(buf: &'a [u8], byte_order: Endianness, offset: u64, dim: WKBDimension) -> Self {
+        Self::try_new(buf, byte_order, offset, dim).unwrap()
+    }
+
+    pub fn try_new(
+        buf: &'a [u8],
+        byte_order: Endianness,
+        mut offset: u64,
+        dim: WKBDimension,
+    ) -> WKBResult<Self> {
+        let has_srid = has_srid(buf, byte_order, offset)?;
         if has_srid {
             offset += 4;
         }
@@ -32,7 +42,10 @@ impl<'a> Polygon<'a> {
         let mut reader = Cursor::new(buf);
         reader.set_position(HEADER_BYTES + offset);
 
-        let num_rings = reader.read_u32(byte_order).unwrap().try_into().unwrap();
+        let num_rings = reader
+            .read_u32(byte_order)?
+            .try_into()
+            .map_err(|e| WKBError::General(format!("Invalid number of rings: {}", e)))?;
 
         // - existing offset into buffer
         // - 1: byteOrder
@@ -41,16 +54,16 @@ impl<'a> Polygon<'a> {
         let mut ring_offset = offset + 1 + 4 + 4;
         let mut wkb_linear_rings = Vec::with_capacity(num_rings);
         for _ in 0..num_rings {
-            let polygon = WKBLinearRing::new(buf, byte_order, ring_offset, dim);
+            let polygon = WKBLinearRing::try_new(buf, byte_order, ring_offset, dim)?;
             wkb_linear_rings.push(polygon);
             ring_offset += polygon.size();
         }
 
-        Self {
+        Ok(Self {
             wkb_linear_rings,
             dim,
             has_srid,
-        }
+        })
     }
 
     /// The number of bytes in this object, including any header

--- a/src/reader/util.rs
+++ b/src/reader/util.rs
@@ -1,7 +1,7 @@
 use byteorder::{BigEndian, LittleEndian};
 
-use crate::common::WKBGeometryCode;
 use crate::Endianness;
+use crate::{common::WKBGeometryCode, error::WKBError};
 use std::io::{Cursor, Error};
 
 pub(crate) trait ReadBytesExt: byteorder::ReadBytesExt {
@@ -25,13 +25,14 @@ pub(crate) trait ReadBytesExt: byteorder::ReadBytesExt {
 impl<R: std::io::Read + ?Sized> ReadBytesExt for R {}
 
 /// Return `true` if this WKB item is EWKB and has an embedded SRID
-pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> bool {
+pub(crate) fn has_srid(buf: &[u8], byte_order: Endianness, offset: u64) -> Result<bool, WKBError> {
     // Read geometry code to see if an SRID exists.
     let mut reader = Cursor::new(buf);
 
     // Skip 1-byte byte order that we already know
     reader.set_position(1 + offset);
 
-    let geometry_code = WKBGeometryCode::new(reader.read_u32(byte_order).unwrap());
-    geometry_code.has_srid()
+    let byte_order_code = reader.read_u32(byte_order)?;
+    let geometry_code = WKBGeometryCode::new(byte_order_code);
+    Ok(geometry_code.has_srid())
 }

--- a/src/test/invalid_ewkb.rs
+++ b/src/test/invalid_ewkb.rs
@@ -1,0 +1,143 @@
+#[cfg(test)]
+mod tests {
+    use crate::reader::Wkb;
+
+    const Z_FLAG: u32 = 0x80000000;
+    const M_FLAG: u32 = 0x40000000;
+    const SRID_FLAG: u32 = 0x20000000;
+
+    // --- Helper Functions ---
+    fn make_ewkb_header(
+        type_id_base: u32,
+        has_z: bool,
+        has_m: bool,
+        has_srid: bool,
+        is_little_endian: bool,
+    ) -> Vec<u8> {
+        let mut type_val = type_id_base;
+        if has_z {
+            type_val |= Z_FLAG;
+        }
+        if has_m {
+            type_val |= M_FLAG;
+        }
+        if has_srid {
+            type_val |= SRID_FLAG;
+        }
+
+        let mut header = vec![if is_little_endian { 0x01 } else { 0x00 }];
+        if is_little_endian {
+            header.extend_from_slice(&type_val.to_le_bytes());
+        } else {
+            header.extend_from_slice(&type_val.to_be_bytes());
+        }
+        header
+    }
+
+    fn srid_bytes(srid: u32, is_little_endian: bool) -> [u8; 4] {
+        if is_little_endian {
+            srid.to_le_bytes()
+        } else {
+            srid.to_be_bytes()
+        }
+    }
+
+    // --- EWKB Point Errors ---
+    #[test]
+    fn test_ewkb_point_srid_flag_but_no_srid_data() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+                                                                           // Missing SRID data (4 bytes), then coords should start
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_point_srid_flag_buffer_too_short_for_srid_value() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+        ewkb_data.extend_from_slice(&[0u8; 2]); // Only 2 bytes for SRID, needs 4
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_point_with_srid_buffer_too_short_for_coords() {
+        let mut ewkb_data = make_ewkb_header(1, false, false, true, true); // Point XY, with SRID flag, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+        ewkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for coords, need 16
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB LineString Errors ---
+    #[test]
+    fn test_ewkb_linestring_with_srid_buffer_too_short_for_num_points() {
+        let mut ewkb_data = make_ewkb_header(2, false, false, true, true); // LineString XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+                                                              // num_points field (4 bytes) is missing
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_linestring_with_srid_num_points_too_large_for_buffer() {
+        let mut ewkb_data = make_ewkb_header(2, false, false, true, true); // LineString XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+        ewkb_data.extend_from_slice(&10u32.to_le_bytes()); // 10 points declared
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // Only 1 point's data (16 bytes)
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes());
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB Polygon Errors ---
+    #[test]
+    fn test_ewkb_polygon_with_srid_buffer_too_short_for_num_rings() {
+        let mut ewkb_data = make_ewkb_header(3, false, false, true, true); // Polygon XY, SRID, LE
+        ewkb_data.extend_from_slice(&srid_bytes(4326, true)); // SRID (4 bytes)
+                                                              // num_rings field (4 bytes) is missing
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- EWKB MultiPoint Errors ---
+    #[test]
+    fn test_ewkb_multipoint_srid_flag_but_no_srid_data_for_outer_geom() {
+        let mut ewkb_data = make_ewkb_header(4, false, false, true, true); // MultiPoint XY, SRID, LE
+                                                                           // Outer SRID missing
+        ewkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point
+                                                          // Contained point (must also have its own header, potentially SRID)
+        let mut contained_point = make_ewkb_header(1, false, false, false, true); // Point XY, no SRID, LE
+        contained_point.extend_from_slice(&1.0f64.to_le_bytes());
+        contained_point.extend_from_slice(&2.0f64.to_le_bytes());
+        ewkb_data.extend(contained_point);
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Z/M Dimension Mismatch (EWKB specific example) ---
+    #[test]
+    fn test_ewkb_point_xyz_flag_but_xy_data() {
+        let mut ewkb_data = make_ewkb_header(1, true, false, false, true); // Point XYZ (Z_FLAG), no SRID, LE
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+                                                            // Missing Z coordinate (8 bytes)
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ewkb_linestring_xyzm_flag_but_xyz_data_for_points() {
+        let type_id_base = 2; // LineString
+        let mut ewkb_data = make_ewkb_header(type_id_base, true, true, false, true); // LineString XYZM, no SRID, LE
+        ewkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point
+                                                          // Coords for 1 point (XYZM = 32 bytes expected per point)
+        ewkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // X
+        ewkb_data.extend_from_slice(&2.0f64.to_le_bytes()); // Y
+        ewkb_data.extend_from_slice(&3.0f64.to_le_bytes()); // Z
+                                                            // Missing M coordinate (8 bytes)
+        let result = Wkb::try_new(&ewkb_data);
+        assert!(result.is_err());
+    }
+}

--- a/src/test/invalid_wkb.rs
+++ b/src/test/invalid_wkb.rs
@@ -1,0 +1,200 @@
+#[cfg(test)]
+mod tests {
+    use crate::reader::Wkb;
+
+    // --- Helper Functions ---
+    fn make_wkb_header(type_id: u32, is_little_endian: bool) -> Vec<u8> {
+        let mut header = vec![if is_little_endian { 0x01 } else { 0x00 }];
+        if is_little_endian {
+            header.extend_from_slice(&type_id.to_le_bytes());
+        } else {
+            header.extend_from_slice(&type_id.to_be_bytes());
+        }
+        header
+    }
+
+    // --- General WKB Errors ---
+    #[test]
+    fn test_wkb_invalid_byte_order() {
+        let wkb_data = vec![0x02, 0x01, 0x00, 0x00, 0x00]; // Invalid byte order 0x02
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_buffer_too_short_for_header() {
+        let wkb_data = vec![0x01, 0x01, 0x00]; // Only 3 bytes, header needs 5
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Point WKB Errors ---
+    #[test]
+    fn test_wkb_point_xy_buffer_too_short_for_coords() {
+        let mut wkb_data = make_wkb_header(1, true); // Point XY, LE = 5 bytes
+        wkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for coords, need 16
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_point_xyz_buffer_too_short_for_coords() {
+        let mut wkb_data = make_wkb_header(1001, true); // Point XYZ, LE = 5 bytes
+        wkb_data.extend_from_slice(&[0u8; 16]); // Only 16 bytes for coords, need 24
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- LineString WKB Errors ---
+    #[test]
+    fn test_wkb_linestring_buffer_too_short_for_num_points() {
+        let wkb_data = make_wkb_header(2, true); // LineString XY, LE = 5 bytes
+                                                 // Missing num_points field (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_linestring_num_points_too_large_for_buffer() {
+        let mut wkb_data = make_wkb_header(2, true); // LineString XY, LE = 5 bytes
+        wkb_data.extend_from_slice(&10u32.to_le_bytes()); // 10 points declared
+        wkb_data.extend_from_slice(&1.0f64.to_le_bytes()); // Only 1 point's data (16 bytes)
+        wkb_data.extend_from_slice(&2.0f64.to_le_bytes());
+        // Total 5 + 4 + 16 = 25 bytes. Expected 5 + 4 + 10*16 = 169 bytes.
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_linestring_invalid_num_points_value() {
+        let mut wkb_data = make_wkb_header(2, true); // LineString XY, LE
+                                                     // u32::MAX num_points would cause massive size calculation if not for try_into error first
+        wkb_data.extend_from_slice(&u32::MAX.to_le_bytes());
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- Polygon WKB Errors ---
+    #[test]
+    fn test_wkb_polygon_buffer_too_short_for_num_rings() {
+        let wkb_data = make_wkb_header(3, true); // Polygon XY, LE = 5 bytes
+                                                 // Missing num_rings field (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_polygon_buffer_too_short_for_ring_num_points() {
+        let mut wkb_data = make_wkb_header(3, true); // Polygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 ring
+                                                         // Missing num_points for the ring (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_polygon_ring_num_points_too_large_for_buffer() {
+        let mut wkb_data = make_wkb_header(3, true); // Polygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 ring
+        wkb_data.extend_from_slice(&4u32.to_le_bytes()); // Ring has 4 points (closed)
+                                                         // Provide data for only 1 point (16 bytes)
+        wkb_data.extend_from_slice(&0.0f64.to_le_bytes());
+        wkb_data.extend_from_slice(&0.0f64.to_le_bytes());
+        // Expected: 5 (poly header) + 4 (num_rings) + 4 (ring num_points) + 4*16 (coords) = 77
+        // Actual:   5 + 4 + 4 + 16 = 29
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiPoint WKB Errors ---
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_num_multipoints_header() {
+        let wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE = 5 bytes
+                                                 // Missing num_points for MultiPoint itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_contained_point_header() {
+        let mut wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point in multipoint
+                                                         // Missing the contained point's WKB header (5 bytes: 1 byte order + 4 type)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipoint_buffer_too_short_for_contained_point_coords() {
+        let mut wkb_data = make_wkb_header(4, true); // MultiPoint XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 point in multipoint
+        wkb_data.extend(make_wkb_header(1, true)); // Contained Point XY header (5 bytes)
+        wkb_data.extend_from_slice(&[0u8; 8]); // Only 8 bytes for contained point's coords, needs 16
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiLineString WKB Errors ---
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_num_multilinestrings_header() {
+        let wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE = 5 bytes
+                                                 // Missing num_linestrings for MultiLineString itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_contained_linestring_header() {
+        let mut wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 linestring
+                                                         // Missing contained linestring's WKB header (5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multilinestring_buffer_too_short_for_contained_linestring_num_points() {
+        let mut wkb_data = make_wkb_header(5, true); // MultiLineString XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 linestring
+        wkb_data.extend(make_wkb_header(2, true)); // Contained LineString XY header (5 bytes)
+                                                   // Missing contained linestring's num_points (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- MultiPolygon WKB Errors ---
+    #[test]
+    fn test_wkb_multipolygon_buffer_too_short_for_num_multipolygons_header() {
+        let wkb_data = make_wkb_header(6, true); // MultiPolygon XY, LE = 5 bytes
+                                                 // Missing num_polygons for MultiPolygon itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_multipolygon_buffer_too_short_for_contained_polygon_header() {
+        let mut wkb_data = make_wkb_header(6, true); // MultiPolygon XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 polygon
+                                                         // Missing contained polygon's WKB header (5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    // --- GeometryCollection WKB Errors ---
+    #[test]
+    fn test_wkb_geomcollection_buffer_too_short_for_num_geometries_header() {
+        let wkb_data = make_wkb_header(7, true); // GeometryCollection XY, LE = 5 bytes
+                                                 // Missing num_geometries for GeometryCollection itself (4 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_wkb_geomcollection_buffer_too_short_for_contained_geometry_header() {
+        let mut wkb_data = make_wkb_header(7, true); // GeometryCollection XY, LE
+        wkb_data.extend_from_slice(&1u32.to_le_bytes()); // 1 geometry
+                                                         // Missing contained geometry's WKB header (e.g., a Point, 5 bytes)
+        let result = Wkb::try_new(&wkb_data);
+        assert!(result.is_err());
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,6 @@
 mod data;
 mod ewkb;
+mod invalid_ewkb;
+mod invalid_wkb;
 mod traits_test;
 mod wkb;


### PR DESCRIPTION
Don't panic when parsing invalid WKB.